### PR TITLE
Add IFSC Finder WordPress plugin

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,161 @@
+// IFSC Finder script using Razorpay API
+// Handles both dropdown-based search and direct IFSC search
+
+// Keep meta data for the currently selected bank
+let stateMap = {};
+let districtMap = {};
+let branchMap = {};
+
+// Initialize when DOM is ready
+window.addEventListener('DOMContentLoaded', () => {
+    loadBanks();
+
+    // Tab controls
+    const selectTab = document.getElementById('by-select-tab');
+    const ifscTab = document.getElementById('by-ifsc-tab');
+    const selectSection = document.getElementById('select-search');
+    const ifscSection = document.getElementById('ifsc-search');
+
+    selectTab.addEventListener('click', () => {
+        selectTab.classList.add('active');
+        ifscTab.classList.remove('active');
+        selectSection.classList.add('active');
+        ifscSection.classList.remove('active');
+    });
+
+    ifscTab.addEventListener('click', () => {
+        ifscTab.classList.add('active');
+        selectTab.classList.remove('active');
+        ifscSection.classList.add('active');
+        selectSection.classList.remove('active');
+    });
+
+    // Dropdown handlers
+    document.getElementById('bank-select').addEventListener('change', loadStates);
+    document.getElementById('state-select').addEventListener('change', loadDistricts);
+    document.getElementById('district-select').addEventListener('change', loadBranches);
+    document.getElementById('branch-select').addEventListener('change', () => {
+        document.getElementById('select-submit').disabled = !document.getElementById('branch-select').value;
+    });
+
+    document.getElementById('select-submit').addEventListener('click', getIfscDetails);
+    document.getElementById('ifsc-submit').addEventListener('click', searchByIFSC);
+});
+
+// Fetch list of banks
+async function loadBanks() {
+    try {
+        const res = await fetch('https://ifsc.razorpay.com/meta/banks');
+        const banks = await res.json();
+        const sel = document.getElementById('bank-select');
+        sel.innerHTML = '<option value="">Select Bank</option>';
+        banks.forEach(bank => sel.appendChild(new Option(bank, bank)));
+    } catch (err) {
+        showError('Unable to load banks');
+    }
+}
+
+// Load states for selected bank
+async function loadStates() {
+    resetSections('state');
+    const bank = document.getElementById('bank-select').value;
+    if (!bank) return;
+    try {
+        const res = await fetch(`https://ifsc.razorpay.com/meta/${encodeURIComponent(bank)}`);
+        stateMap = await res.json();
+        const sel = document.getElementById('state-select');
+        sel.innerHTML = '<option value="">Select State</option>';
+        Object.keys(stateMap).forEach(state => sel.appendChild(new Option(state, state)));
+        sel.disabled = false;
+    } catch (err) {
+        showError('Unable to load states');
+    }
+}
+
+// Load districts for selected state
+function loadDistricts() {
+    resetSections('district');
+    const state = document.getElementById('state-select').value;
+    if (!state) return;
+    districtMap = stateMap[state] || {};
+    const sel = document.getElementById('district-select');
+    sel.innerHTML = '<option value="">Select District</option>';
+    Object.keys(districtMap).forEach(d => sel.appendChild(new Option(d, d)));
+    sel.disabled = false;
+}
+
+// Load branches for selected district
+function loadBranches() {
+    resetSections('branch');
+    const district = document.getElementById('district-select').value;
+    if (!district) return;
+    branchMap = districtMap[district] || {};
+    const sel = document.getElementById('branch-select');
+    sel.innerHTML = '<option value="">Select Branch</option>';
+    Object.keys(branchMap).forEach(b => sel.appendChild(new Option(b, b)));
+    sel.disabled = false;
+}
+
+// Fetch details based on dropdown selection
+async function getIfscDetails() {
+    const branch = document.getElementById('branch-select').value;
+    if (!branch || !branchMap[branch]) return;
+    const ifsc = branchMap[branch];
+    fetchAndDisplay(ifsc);
+}
+
+// Search details by direct IFSC input
+async function searchByIFSC() {
+    const ifsc = document.getElementById('ifsc-input').value.trim().toUpperCase();
+    if (!ifsc) {
+        showError('Enter IFSC code');
+        return;
+    }
+    fetchAndDisplay(ifsc);
+}
+
+// Common fetch function to display IFSC details
+async function fetchAndDisplay(ifsc) {
+    clearOutput();
+    try {
+        const res = await fetch(`https://ifsc.razorpay.com/${ifsc}`);
+        if (!res.ok) throw new Error('Invalid IFSC code');
+        const data = await res.json();
+        const out = document.getElementById('resultOutput');
+        out.innerHTML =
+            `<div><strong>BANK:</strong> ${data.BANK}</div>`+
+            `<div><strong>BRANCH:</strong> ${data.BRANCH}</div>`+
+            `<div><strong>ADDRESS:</strong> ${data.ADDRESS}</div>`+
+            `<div><strong>CITY:</strong> ${data.CITY}</div>`+
+            `<div><strong>STATE:</strong> ${data.STATE}</div>`+
+            `<div><strong>MICR:</strong> ${data.MICR}</div>`+
+            `<div><strong>IFSC:</strong> ${data.IFSC}</div>`;
+    } catch (err) {
+        showError(err.message);
+    }
+}
+
+// Helpers to manage UI states
+function resetSections(level) {
+    if (level === 'state') {
+        document.getElementById('state-select').innerHTML = '<option value="">Select State</option>';
+        document.getElementById('state-select').disabled = true;
+    }
+    if (level === 'state' || level === 'district') {
+        document.getElementById('district-select').innerHTML = '<option value="">Select District</option>';
+        document.getElementById('district-select').disabled = true;
+    }
+    document.getElementById('branch-select').innerHTML = '<option value="">Select Branch</option>';
+    document.getElementById('branch-select').disabled = true;
+    document.getElementById('select-submit').disabled = true;
+}
+
+function showError(msg) {
+    const err = document.getElementById('error-message');
+    err.textContent = msg;
+}
+
+function clearOutput() {
+    showError('');
+    document.getElementById('resultOutput').innerHTML = '';
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,87 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
+/* Container styling */
+.ifsc-finder-container {
+    max-width: 520px;
+    margin: 40px auto;
+    padding: 20px;
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+    font-family: 'Inter', sans-serif;
+}
+
+/* Tab navigation */
+.ifsc-tabs {
+    text-align: center;
+    margin-bottom: 20px;
+}
+.ifsc-tabs button {
+    padding: 8px 16px;
+    margin: 0 4px;
+    border: none;
+    background: #f1f5f9;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+.ifsc-tabs button.active {
+    background: #1e293b;
+    color: #fff;
+}
+.ifsc-tabs button:hover {
+    background: #e2e8f0;
+}
+
+/* Search sections */
+.ifsc-search-section {
+    display: none;
+    flex-direction: column;
+    gap: 10px;
+}
+.ifsc-search-section.active {
+    display: flex;
+}
+
+.ifsc-search-section select,
+.ifsc-search-section input {
+    padding: 8px 10px;
+    border: 1px solid #cbd5e1;
+    border-radius: 4px;
+}
+.ifsc-search-section button {
+    padding: 10px;
+    border: none;
+    border-radius: 4px;
+    background: #1e293b;
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+.ifsc-search-section button:hover {
+    background: #334155;
+}
+
+/* Result box */
+#resultOutput {
+    margin-top: 20px;
+    border: 1px solid #e2e8f0;
+    background: #f8fafc;
+    padding: 15px;
+    border-radius: 6px;
+}
+#resultOutput div {
+    margin-bottom: 6px;
+}
+
+#error-message {
+    color: #dc2626;
+    margin-top: 10px;
+}
+
+@media (max-width: 600px) {
+    .ifsc-finder-container {
+        margin: 20px 10px;
+        padding: 15px;
+    }
+}

--- a/ifsc-finder.php
+++ b/ifsc-finder.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Plugin Name: IFSC Finder
+ * Description: Single Page IFSC Code Finder using Razorpay IFSC API.
+ * Version: 1.0.0
+ * Author: Codex
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Enqueue plugin assets when shortcode is used.
+ */
+function ifsc_finder_enqueue_assets() {
+    wp_enqueue_style( 'ifsc-finder-style', plugins_url( 'assets/style.css', __FILE__ ), array(), '1.0' );
+    wp_enqueue_script( 'ifsc-finder-script', plugins_url( 'assets/script.js', __FILE__ ), array(), '1.0', true );
+}
+
+/**
+ * Shortcode callback that renders the IFSC finder interface.
+ */
+function ifsc_finder_render() {
+    // Enqueue assets only when shortcode is rendered
+    ifsc_finder_enqueue_assets();
+
+    ob_start();
+    ?>
+    <div class="ifsc-finder-container">
+        <div class="ifsc-tabs">
+            <button id="by-select-tab" class="active" type="button">Search by Bank</button>
+            <button id="by-ifsc-tab" type="button">Search by IFSC Code</button>
+        </div>
+        <div id="select-search" class="ifsc-search-section active">
+            <select id="bank-select">
+                <option value="">Select Bank</option>
+            </select>
+            <select id="state-select" disabled>
+                <option value="">Select State</option>
+            </select>
+            <select id="district-select" disabled>
+                <option value="">Select District</option>
+            </select>
+            <select id="branch-select" disabled>
+                <option value="">Select Branch</option>
+            </select>
+            <button id="select-submit" type="button" disabled>Show IFSC</button>
+        </div>
+        <div id="ifsc-search" class="ifsc-search-section">
+            <input type="text" id="ifsc-input" placeholder="Enter IFSC Code" />
+            <button id="ifsc-submit" type="button">Show Details</button>
+        </div>
+        <div id="error-message"></div>
+        <div id="resultOutput"></div>
+    </div>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode( 'ifsc_finder', 'ifsc_finder_render' );


### PR DESCRIPTION
## Summary
- implement `ifsc-finder.php` WordPress plugin
- add modern styles for responsive shortcode output
- add JavaScript for dynamic API calls

## Testing
- `php -l ifsc-finder.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411d2a4ed08332b6461aa7227b15f6